### PR TITLE
Making the annotations page mobile friendly

### DIFF
--- a/src/components/Annotations/AnnotationList.js
+++ b/src/components/Annotations/AnnotationList.js
@@ -18,7 +18,8 @@ const styles = (theme) => ({
   base: {
     border: '1px solid rgba(255,255,255,0.04)',
     borderRadius: 5,
-    overflow: 'hidden'
+    height: 600,
+    width: '100%',
   }
 });
 
@@ -46,11 +47,12 @@ class AnnotationList extends PureComponent {
 
   filter = memoize((resolved, unresolved, list) => list.filter(this.filterEntry));
 
-  recomputeList = () => {
-    if (this.list) {
-      this.list.recomputeRowHeights();
-      this.list.forceUpdateGrid();
-    }
+  getEvent(index) {
+    const { segment } = this.props;
+    const events = (segment || {}).events || [];
+    const filteredList = this.filter(this.props.resolved, this.props.unresolved, events);
+
+    return filteredList[index];
   }
 
   handleExpanded = (eventId, timestamp) => {
@@ -76,12 +78,11 @@ class AnnotationList extends PureComponent {
     }
   }
 
-  getEvent(index) {
-    const { segment } = this.props;
-    const events = (segment || {}).events || [];
-    const filteredList = this.filter(this.props.resolved, this.props.unresolved, events);
-
-    return filteredList[index];
+  recomputeList = () => {
+    if (this.list) {
+      this.list.recomputeRowHeights();
+      this.list.forceUpdateGrid();
+    }
   }
 
   getRowHeight = ({ index }) => {
@@ -92,32 +93,6 @@ class AnnotationList extends PureComponent {
     const expanded = this.state.expanded === eventId;
 
     return !expanded ? 64 : 314; // TODO: is 314 safe?
-  }
-
-  render() {
-    const {
-      segment, classes, resolved, unresolved
-    } = this.props;
-    const events = (segment || {}).events || [];
-
-    return (
-      <div className={classes.base} style={{ height: '100%' }}>
-        <AutoSizer>
-          {({ height, width }) => (
-            <List
-              ref={(ref) => this.list = ref}
-              height={height}
-              width={width}
-              overscanRowCount={10}
-              // noRowsRenderer={this.noRowsRenderer}
-              rowCount={this.filter(resolved, unresolved, events).length}
-              rowHeight={this.getRowHeight}
-              rowRenderer={this.renderEntry}
-            />
-          )}
-        </AutoSizer>
-      </div>
-    );
   }
 
   filterEntry = (event) => {
@@ -145,6 +120,32 @@ class AnnotationList extends PureComponent {
         disabled={!segment.hpgps}
         onChange={partial(this.handleExpanded, eventId, event.timestamp)}
       />
+    );
+  }
+
+  render() {
+    const {
+      segment, classes, resolved, unresolved
+    } = this.props;
+    const events = (segment || {}).events || [];
+
+    return (
+      <div className={classes.base}>
+        <AutoSizer>
+          {({ height, width }) => (
+            <List
+              ref={(ref) => this.list = ref}
+              height={height}
+              width={width}
+              overscanRowCount={10}
+              // noRowsRenderer={this.noRowsRenderer}
+              rowCount={this.filter(resolved, unresolved, events).length}
+              rowHeight={this.getRowHeight}
+              rowRenderer={this.renderEntry}
+            />
+          )}
+        </AutoSizer>
+      </div>
     );
   }
 }

--- a/src/components/Annotations/AnnotationTabs.js
+++ b/src/components/Annotations/AnnotationTabs.js
@@ -14,14 +14,11 @@ import { filterEvent } from '../../utils';
 
 const styles = (theme) => ({
   root: {
+    height: '100%',
+    width: '100%',
   },
   annotationsViewer: {
     display: 'flex',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
     overflow: 'hidden',
     flexDirection: 'column',
   },
@@ -49,6 +46,8 @@ const styles = (theme) => ({
   annotationsViewerList: {
     height: '100%',
     overflowY: 'scroll',
+    width: '100%',
+    flex: 1,
   },
 });
 
@@ -81,10 +80,31 @@ class AnnotationTabs extends Component {
     }).length;
   }
 
+  renderTab(index) {
+    switch (index) {
+      case 0:
+        return (
+          <AnnotationList
+            segment={this.props.segment}
+            unresolved
+          />
+        );
+      case 1:
+        return (<AnnotationList segment={this.props.segment} resolved />);
+      default:
+        return (
+          <AnnotationList
+            segment={this.props.segment}
+            unresolved
+          />
+        );
+    }
+  }
+
   render() {
     const { classes } = this.props;
     return (
-      <div style={{ position: 'relative', height: '100%' }}>
+      <div className={classes.root}>
         <div className={classes.annotationsViewer}>
           <Tabs
             value={this.state.selectedTab}
@@ -119,20 +139,6 @@ class AnnotationTabs extends Component {
         </div>
       </div>
     );
-  }
-
-  renderTab(index) {
-    switch (index) {
-      case 0:
-        return (
-          <AnnotationList
-            segment={this.props.segment}
-            unresolved
-          />
-        );
-      case 1:
-        return (<AnnotationList segment={this.props.segment} resolved />);
-    }
   }
 }
 

--- a/src/components/Annotations/Media.js
+++ b/src/components/Annotations/Media.js
@@ -22,8 +22,8 @@ const styles = (theme) => ({
     border: '1px solid rgba(255,255,255,.1)',
     borderRadius: 50,
     display: 'flex',
-    marginLeft: 'auto',
-    marginBottom: 12,
+    margin: '12px 0px',
+    width: '70%',
   },
   mediaOption: {
     alignItems: 'center',
@@ -84,6 +84,74 @@ class Media extends Component {
     };
   }
 
+  renderMediaOptions() {
+    const { classes, currentSegment } = this.props;
+    const { inView } = this.state;
+    const mediaSource = 'eon-road-camera';
+    const hasDriverCameraStream = this.props.currentSegment && this.props.currentSegment.hasDriverCameraStream;
+    return (
+      <Grid container justify="center" alignItems="center" className={classes.mediaOptions}>
+        {/* <Grid
+          item
+          xs={hasDriverCameraStream ? 5 : 7}
+        /> */}
+        {/* <Grid
+          item
+          xs={hasDriverCameraStream ? 7 : 5}
+          className={classes.mediaOptions}
+        > */}
+        <Grid
+          item
+          xs={hasDriverCameraStream ? 3 : 4}
+          className={classes.mediaOption}
+          style={inView === MediaType.HUD ? { opacity: 1 } : { }}
+          onClick={() => this.setState({ inView: MediaType.HUD })}
+        >
+          <Typography className={classes.mediaOptionText}>
+            HUD
+          </Typography>
+        </Grid>
+        <Grid
+          item
+          xs={hasDriverCameraStream ? 3 : 4}
+          className={classes.mediaOption}
+          style={inView === MediaType.VIDEO ? { opacity: 1 } : {}}
+          onClick={() => this.setState({ inView: MediaType.VIDEO })}
+        >
+          <Typography className={classes.mediaOptionText}>
+            Video
+          </Typography>
+        </Grid>
+        { hasDriverCameraStream
+          && (
+          <Grid
+            item
+            // xs={3}
+            className={cx(classes.mediaOption, { disabled: !hasDriverCameraStream })}
+            style={inView === MediaType.DRIVER_VIDEO ? { opacity: 1 } : {}}
+            onClick={() => hasDriverCameraStream && this.setState({ inView: MediaType.DRIVER_VIDEO })}
+          >
+            <Typography className={classes.mediaOptionText}>
+              Driver Video
+            </Typography>
+          </Grid>
+          )}
+        <Grid
+          item
+          xs={hasDriverCameraStream ? 3 : 4}
+          className={classes.mediaOption}
+          style={inView === MediaType.MAP ? { opacity: 1 } : { }}
+          onClick={() => this.setState({ inView: MediaType.MAP })}
+        >
+          <Typography className={classes.mediaOptionText}>
+            Map
+          </Typography>
+        </Grid>
+        {/* </Grid> */}
+      </Grid>
+    );
+  }
+
   render() {
     const { classes } = this.props;
     const { inView } = this.state;
@@ -102,74 +170,6 @@ class Media extends Component {
           />
           )}
       </>
-    );
-  }
-
-  renderMediaOptions() {
-    const { classes, currentSegment } = this.props;
-    const { inView } = this.state;
-    const mediaSource = 'eon-road-camera';
-    const hasDriverCameraStream = this.props.currentSegment && this.props.currentSegment.hasDriverCameraStream;
-    return (
-      <Grid container>
-        <Grid
-          item
-          xs={hasDriverCameraStream ? 5 : 7}
-        />
-        <Grid
-          item
-          xs={hasDriverCameraStream ? 7 : 5}
-          className={classes.mediaOptions}
-        >
-          <Grid
-            item
-            xs={hasDriverCameraStream ? 3 : 4}
-            className={classes.mediaOption}
-            style={inView === MediaType.HUD ? { opacity: 1 } : { }}
-            onClick={() => this.setState({ inView: MediaType.HUD })}
-          >
-            <Typography className={classes.mediaOptionText}>
-              HUD
-            </Typography>
-          </Grid>
-          <Grid
-            item
-            xs={hasDriverCameraStream ? 3 : 4}
-            className={classes.mediaOption}
-            style={inView === MediaType.VIDEO ? { opacity: 1 } : {}}
-            onClick={() => this.setState({ inView: MediaType.VIDEO })}
-          >
-            <Typography className={classes.mediaOptionText}>
-              Video
-            </Typography>
-          </Grid>
-          { hasDriverCameraStream
-            && (
-            <Grid
-              item
-              xs={3}
-              className={cx(classes.mediaOption, { disabled: !hasDriverCameraStream })}
-              style={inView === MediaType.DRIVER_VIDEO ? { opacity: 1 } : {}}
-              onClick={() => hasDriverCameraStream && this.setState({ inView: MediaType.DRIVER_VIDEO })}
-            >
-              <Typography className={classes.mediaOptionText}>
-                Driver Video
-              </Typography>
-            </Grid>
-            )}
-          <Grid
-            item
-            xs={hasDriverCameraStream ? 3 : 4}
-            className={classes.mediaOption}
-            style={inView === MediaType.MAP ? { opacity: 1 } : { }}
-            onClick={() => this.setState({ inView: MediaType.MAP })}
-          >
-            <Typography className={classes.mediaOptionText}>
-              Map
-            </Typography>
-          </Grid>
-        </Grid>
-      </Grid>
     );
   }
 }

--- a/src/components/Annotations/footer.js
+++ b/src/components/Annotations/footer.js
@@ -21,7 +21,6 @@ const styles = (theme) => ({
   root: {
     width: '100%',
     height: '100%',
-    paddingTop: theme.spacing.unit,
     background: 'transparent',
     textAlign: 'right'
   },

--- a/src/components/Annotations/index.js
+++ b/src/components/Annotations/index.js
@@ -27,15 +27,9 @@ const styles = (theme) => ({
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
-  },
-  window: {
-    background: 'linear-gradient(to bottom, #30373B 0%, #272D30 10%, #1D2225 100%)',
-    borderRadius: 8,
-    display: 'flex',
-    flexDirection: 'column',
-    flexGrow: 1,
+    width: '100vw',
     overflowY: 'scroll',
-    margin: 18,
+    paddingLeft: 12
   },
   header: {},
   headerContext: {
@@ -54,15 +48,20 @@ const styles = (theme) => ({
     marginLeft: 'auto',
   },
   headerTimeline: {},
-  viewer: {
+  largeViewer: {
     padding: theme.spacing.unit * 4,
+  },
+  videoHalf: {
+    marginRight: 10
   },
   footer: {
     alignItems: 'center',
     background: 'linear-gradient(to bottom, #30373B 0%, #272D30 10%, #1D2225 100%)',
     display: 'flex',
-    marginTop: 'auto',
     width: '100%',
+  },
+  annotations: {
+    height: '100%',
   },
 });
 
@@ -77,9 +76,37 @@ class Annotations extends Component {
     this.props.dispatch(selectRange(null, null));
   }
 
-  renderAnnotationsElement(visibleSegment) {
-    return (<AnnotationTabs segment={visibleSegment} />);
-  }
+  renderAnnotationsElement = (visibleSegment) => (
+    <AnnotationTabs segment={visibleSegment} />
+  );
+
+  renderLargeScreen = (classes, visibleSegment) => (
+    <div className={classes.largeViewer}>
+      <Grid container wrap="nowrap">
+        <Grid className={classes.videoHalf} container wrap="nowrap" direction="column" alignItems="center">
+          <Media />
+          <TimeDisplay isThin />
+        </Grid>
+        <Grid container className={classes.annotations}>
+          { visibleSegment && this.renderAnnotationsElement(visibleSegment) }
+        </Grid>
+      </Grid>
+    </div>
+  );
+
+  renderSmallScreen = (classes, visibleSegment) => (
+    <div className={classes.viewer}>
+      <Grid container direction="column" alignItems="center">
+        <Grid container wrap="nowrap" direction="column" alignItems="center">
+          <Media />
+          <TimeDisplay isThin />
+        </Grid>
+        <Grid container className={classes.annotations}>
+          { visibleSegment && this.renderAnnotationsElement(visibleSegment) }
+        </Grid>
+      </Grid>
+    </div>
+  );
 
   render() {
     const {
@@ -92,46 +119,36 @@ class Annotations extends Component {
     } = this.props;
     const visibleSegment = (currentSegment || nextSegment);
     const routeName = visibleSegment ? visibleSegment.route : 'Nothing visible';
-    const shortName = routeName.split('|')[1];
+    // const shortName = routeName.split('|')[1];
+    let annotations;
+    if (screen.width < 850) {
+      console.log('rendering small screen');
+      annotations = this.renderSmallScreen(classes, visibleSegment);
+    } else {
+      console.log('rendering large screen');
+      annotations = this.renderLargeScreen(classes, visibleSegment);
+    }
+
     return (
       <div className={classes.base}>
-        <div className={classes.window}>
-          <div className={classes.header}>
-            <div className={classes.headerContext}>
-              <IconButton aria-label="Go Back" onClick={() => window.history.back()}>
-                <KeyboardBackspaceIcon />
-              </IconButton>
-              <Typography className={classes.headerTitle}>
-                { this.props.device.alias }
-              </Typography>
-              <div className={classes.headerActions}>
-                <IconButton onClick={this.close} aria-label="Close">
-                  <CloseIcon />
-                </IconButton>
-              </div>
-            </div>
-            <Timeline
-              className={classes.headerTimeline}
-              zoomed
-              colored
-              hasThumbnails
-              hasRuler
-              hasGradient
-              tooltipped
-              dragSelection
-            />
+        <div className={classes.header}>
+          <div className={classes.headerContext}>
+            <Typography className={classes.headerTitle}>
+              { this.props.device.alias }
+            </Typography>
           </div>
-          <div className={classes.viewer}>
-            <Grid container spacing={32}>
-              <Grid item xs={6}>
-                { visibleSegment && this.renderAnnotationsElement(visibleSegment) }
-              </Grid>
-              <Grid item xs={6}>
-                <Media />
-              </Grid>
-            </Grid>
-          </div>
+          <Timeline
+            className={classes.headerTimeline}
+            zoomed
+            colored
+            hasThumbnails
+            hasRuler
+            hasGradient
+            tooltipped
+            dragSelection
+          />
         </div>
+        {annotations}
         <div className={classes.footer}>
           <AnnotationsFooter segment={visibleSegment} loop={loop} start={start} />
         </div>

--- a/src/components/AppHeader/index.js
+++ b/src/components/AppHeader/index.js
@@ -20,7 +20,6 @@ import IconButton from '@material-ui/core/IconButton';
 import MyCommaAuth from '@commaai/my-comma-auth';
 
 import TimeFilter from './TimeFilter';
-import TimeDisplay from '../TimeDisplay';
 import { AccountIcon } from '../../icons';
 
 import Timelineworker from '../../timeline';
@@ -47,9 +46,6 @@ const styles = (theme) => ({
     fontFamily: 'MaisonNeueExtended',
     fontSize: 18,
     fontWeight: 600,
-  },
-  timeDisplay: {
-    alignItems: 'center',
   },
   selectArea: {
     alignItems: 'center',
@@ -120,9 +116,6 @@ class AppHeader extends Component {
                 explorer
               </Typography>
             </Link>
-          </Grid>
-          <Grid item container xs={6} lg={4} className={classes.timeDisplay}>
-            <TimeDisplay isThin />
           </Grid>
           <Grid
             item

--- a/src/components/TimeDisplay/index.js
+++ b/src/components/TimeDisplay/index.js
@@ -46,7 +46,6 @@ const styles = (theme) => ({
     padding: theme.spacing.unit,
     maxWidth: 510,
     margin: '0 auto',
-    minWidth: 450,
     opacity: 0,
     pointerEvents: 'none',
     transition: 'opacity 0.1s ease-in-out',


### PR DESCRIPTION
I made two separate renders of the annotations page. One that renders horizontally and one that renders vertically for mobile. The mobile video size is also smaller because the AutoSizer requires a fixed size. I moved the entire annotations page outside of the card as well. Also, I cleaned up linter issues where I saw them.