### PR TITLE
modify MuiPickersUtilsProvider path in material-ui-pickers module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import document from 'global/document';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { MuiThemeProvider } from '@material-ui/core/styles';
-import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
+import MuiPickersUtilsProvider from 'material-ui-pickers/MuiPickersUtilsProvider';
 import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
 
 import './index.css';


### PR DESCRIPTION
Add this modification to avoid "Can't resolve 'material-ui-pickers/utils/MuiPickersUtilsProvider'" error while executing "yarn start". 